### PR TITLE
Configure Rubocop

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,22 @@
+name: Rubocop
+on: [push]
+
+jobs:
+  linters:
+    name: Linters
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v3.6.0
+
+      - name: Run linters
+        run: |
+          bin/rubocop --parallel


### PR DESCRIPTION
This pull request adds a Rubocop linter to the repository. Rubocop is a Ruby static code analyzer and code formatter that enforces a consistent coding style and detects common code smells.

The Rubocop linter job is set up to run on every push to the repository. It runs on an Ubuntu latest operating system and uses the latest version of Ruby and Node.js. The linter job checks for any style violations in the codebase using the `bin/rubocop` command with the `--parallel` flag for faster execution.

With the addition of this linter, developers can ensure that their code adheres to the team's coding style guidelines and catch potential errors before they are merged into the codebase.
