### PR TITLE
Fix RedisClient::CannotConnectError

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -3,13 +3,15 @@
 Sidekiq.configure_server do |config|
   config.redis = {
     url: ENV.fetch('REDIS_URL', nil),
-    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE },
+    network_timeout: 5
   }
 end
 
 Sidekiq.configure_client do |config|
   config.redis = {
     url: ENV.fetch('REDIS_URL', nil),
-    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE },
+    network_timeout: 5
   }
 end


### PR DESCRIPTION
Adjust network Redis network timeout for [Life in the Cloud](https://github.com/sidekiq/sidekiq/wiki/Using-Redis#life-in-the-cloud)